### PR TITLE
Remove faux-bold text

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -17,7 +17,7 @@
 		<link rel="stylesheet" href="assets/style.css">
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@500;700&family=Heebo:wght@500&display=swap" rel="stylesheet"> 
+		<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@500;700&family=Heebo:wght@500;700&display=swap" rel="stylesheet">
 		
 
 		%sveltekit.head%


### PR DESCRIPTION
Add the bold weight of Heebo so that bold text is not rendered in a faux-bolded font.

Before:

<img width="317" alt="Before" src="https://user-images.githubusercontent.com/68767503/178197748-22946609-1fab-4d7f-9981-fcfbfdce5ce1.png">

After:

<img width="318" alt="After" src="https://user-images.githubusercontent.com/68767503/178197816-8f671a51-3019-4945-a593-ddc8aaf091b6.png">