### PR TITLE
Issue 9 - Data structure/Definition component

### DIFF
--- a/src/lib/definition.svelte
+++ b/src/lib/definition.svelte
@@ -1,0 +1,10 @@
+<script>
+export let term = '';
+export let definition = '';
+
+definition = definition.replace(`${term}`, `<strong>${term.toLowerCase()}</strong>`);
+
+</script>
+<dt>{term}</dt>
+<dd>{definition}</dd>
+<style>/* Just leaving this here so it exists in the component */</style>

--- a/src/lib/definition.svelte
+++ b/src/lib/definition.svelte
@@ -1,10 +1,29 @@
 <script>
 export let term = '';
 export let definition = '';
-
-definition = definition.replace(`${term}`, `<strong>${term.toLowerCase()}</strong>`);
+export let category = '';
+definition = definition.replace(`${term.toLowerCase()}`, `<strong>${term.toLowerCase()}</strong>`);
 
 </script>
 <dt>{term}</dt>
-<dd>{definition}</dd>
-<style>/* Just leaving this here so it exists in the component */</style>
+<dd>
+    <!-- since list-style-type none can mess with the default role attribute, redundantly declaring it as well -->
+    <ul role="list">
+        {#if category !== ''}
+            <li class="category">Category: {category}</li>
+        {/if}
+        <li class="definition">{@html definition}</li>
+    </ul>
+</dd>
+<style>
+    ul {
+        list-style-type: none;
+        padding-left: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25ch;
+    }
+    .category {
+        font-size: 1.1rem;
+    }
+</style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,3 +1,6 @@
+<script>
+  import Definition from "../lib/definition.svelte";
+</script>
 <svelte:head>
   <title>Collective Nouns for the Web</title>
 </svelte:head>
@@ -13,6 +16,11 @@
   <section>
     <!-- <h2>List of Collective Nouns</h2> -->
     <dl>
+      <Definition
+        term="Vanity"
+        definition="A vanity is ten(10) or more domains owned by a single person, where very few are in use."
+        category="Judgemental"
+      />
       <dt>Vanity</dt>
       <dd>A <strong>vanity</strong> is ten(10) or more domains owned by a single person, where very few are in use.</dd>
       <dt>Arsenal</dt>


### PR DESCRIPTION
Adds a `<Definition>` component with the props, `term`, `definition`, and `category`. 

There is an example on the `index.svelte` page which shows the potential differences between the current and the proposed.